### PR TITLE
일정스토리카드 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
         "react-router": "^7.9.1",
-        "tailwindcss": "^4.1.13",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -23,10 +22,13 @@
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.13",
         "vite": "^7.1.2"
       }
     },
@@ -1710,6 +1712,44 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
@@ -2426,6 +2466,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
@@ -3196,6 +3250,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3324,6 +3388,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,10 @@
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
-        "autoprefixer": "^10.4.21",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
-        "postcss": "^8.5.6",
         "tailwindcss": "^4.1.13",
         "vite": "^7.1.2"
       }
@@ -1712,44 +1710,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/axios": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
@@ -2466,20 +2426,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
@@ -3250,16 +3196,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3388,13 +3324,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
     "react-router": "^7.9.1",
-    "tailwindcss": "^4.1.13",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
@@ -25,10 +24,13 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.13",
     "vite": "^7.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
-    "autoprefixer": "^10.4.21",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
     "vite": "^7.1.2"
   }

--- a/src/assets/data/dummySchedule.js
+++ b/src/assets/data/dummySchedule.js
@@ -1,0 +1,11 @@
+export const dummySchedule = {
+  post_id: 1,
+  title: "일정스토리의 제목입니다.",
+  start_time: "...",
+  category: "...",
+  is_shared: true,
+  like_count: 500,
+  favorite_count: 200,
+  is_reported: false,
+  is_completed: false,
+};

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -22,3 +22,4 @@ function ScheduleStoryCard({ schedule }) {
     </div>
   );
 }
+export default ScheduleStoryCard;

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -1,0 +1,24 @@
+function ScheduleStoryCard({ schedule }) {
+  return (
+    <div className="w-[500px] bg-white rounded-lg shadow p-5 mb-4 cursor-pointer hover:shadow-lg transition">
+      {/* 제목 */}
+      <h3
+        className="text-xl font-semibold mb-3 truncate"
+        title={schedule.title}
+      >
+        {schedule.title}
+      </h3>
+
+      {/* 스토리 카드 내용 (요약) */}
+      <p className="text-gray-700 mb-4 line-clamp-3">
+        {schedule.story || "내용이 없습니다."}
+      </p>
+
+      {/* 좋아요 & 찜하기 */}
+      <div className="flex space-x-6 text-gray-600 text-sm font-medium">
+        <div>👍 좋아요: {schedule.like_count ?? 0}</div>
+        <div>💖 찜하기: {schedule.favorite_count ?? 0}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -1,6 +1,9 @@
 function ScheduleStoryCard({ schedule }) {
   return (
-    <div className="w-[500px] bg-white rounded-lg shadow p-5 mb-4 cursor-pointer hover:shadow-lg transition">
+    <div className="w-[300px] bg-white rounded-lg shadow p-5 mb-4 cursor-pointer hover:shadow-lg transition">
+      {/* 이미지 또는 플레이스홀더 박스 */}
+      <div className="bg-gray-300 rounded-md h-32 mb-4 w-full"></div>
+
       {/* 제목 */}
       <h3
         className="text-xl font-semibold mb-3 truncate"
@@ -9,12 +12,7 @@ function ScheduleStoryCard({ schedule }) {
         {schedule.title}
       </h3>
 
-      {/* 스토리 카드 내용 (요약) */}
-      <p className="text-gray-700 mb-4 line-clamp-3">
-        {schedule.story || "내용이 없습니다."}
-      </p>
-
-      {/* 좋아요 & 찜하기 */}
+      {/* 좋아요 & 찜하기 (이모지로 심플하게) */}
       <div className="flex space-x-6 text-gray-600 text-sm font-medium">
         <div>👍 좋아요: {schedule.like_count ?? 0}</div>
         <div>💖 찜하기: {schedule.favorite_count ?? 0}</div>
@@ -22,4 +20,5 @@ function ScheduleStoryCard({ schedule }) {
     </div>
   );
 }
+
 export default ScheduleStoryCard;

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -8,12 +8,12 @@ function ScheduleStoryCard({ schedule }) {
       <div className="bg-gray-300 rounded-md h-32 mb-4 w-[300px]"></div>
 
       {/* 제목 */}
-      <h3
+      <h2
         className="text-xl font-semibold mb-3 truncate"
         title={schedule.title}
       >
         {schedule.title}
-      </h3>
+      </h2>
 
       {/* 좋아요 & 찜하기 */}
       <div className="flex space-x-6 text-gray-600 text-sm font-medium justify-center">

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -1,8 +1,11 @@
 function ScheduleStoryCard({ schedule }) {
   return (
-    <div className="w-[300px] bg-white rounded-lg shadow p-5 mb-4 cursor-pointer hover:shadow-lg transition">
-      {/* 이미지 또는 플레이스홀더 박스 */}
-      <div className="bg-gray-300 rounded-md h-32 mb-4 w-full"></div>
+    <div
+      className="w-[350px] bg-white rounded-lg shadow p-5 mb-4 cursor-pointer hover:shadow-lg transition 
+    flex flex-col items-center justify-center text-center"
+    >
+      {/* 회색 박스 */}
+      <div className="bg-gray-300 rounded-md h-32 mb-4 w-[300px]"></div>
 
       {/* 제목 */}
       <h3
@@ -12,13 +15,12 @@ function ScheduleStoryCard({ schedule }) {
         {schedule.title}
       </h3>
 
-      {/* 좋아요 & 찜하기 (이모지로 심플하게) */}
-      <div className="flex space-x-6 text-gray-600 text-sm font-medium">
-        <div>👍 좋아요: {schedule.like_count ?? 0}</div>
-        <div>💖 찜하기: {schedule.favorite_count ?? 0}</div>
+      {/* 좋아요 & 찜하기 */}
+      <div className="flex space-x-6 text-gray-600 text-sm font-medium justify-center">
+        <div> 좋아요: {schedule.like_count ?? 0}</div>
+        <div> 찜하기: {schedule.favorite_count ?? 0}</div>
       </div>
     </div>
   );
 }
-
 export default ScheduleStoryCard;

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,8 +1,19 @@
+import ScheduleStoryCard from "./ScheduleStoryCard";
+
 function Test() {
+  const dummySchedule = {
+    id: 1,
+    title: "오로지 내 취향으로만 가득한 여행일정!",
+    likes: 22,
+    bookmarks: 207,
+    isBookmarked: false,
+    isReported: false,
+  };
+
   return (
-    <>
-      <div>test</div>
-    </>
+    <div>
+      <ScheduleStoryCard schedule={dummySchedule} isAdmin={false} />
+    </div>
   );
 }
 

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -2,17 +2,20 @@ import ScheduleStoryCard from "./ScheduleStoryCard";
 
 function Test() {
   const dummySchedule = {
-    id: 1,
-    title: "오로지 내 취향으로만 가득한 여행일정!",
-    likes: 22,
-    bookmarks: 207,
-    isBookmarked: false,
-    isReported: false,
+    post_id: 1,
+    title: "일정스토리의 제목입니다.",
+    start_time: "...",
+    category: "...",
+    is_shared: true,
+    like_count: 500,
+    favorite_count: 200,
+    is_reported: false,
+    is_completed: false,
   };
 
   return (
     <div>
-      <ScheduleStoryCard schedule={dummySchedule} isAdmin={false} />
+      <ScheduleStoryCard schedule={dummySchedule} />
     </div>
   );
 }

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,46 +1,18 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
-import ScheduleStoryCard from "./ScheduleStoryCard"; // 경로 네가 맞게 수정
+import ScheduleStoryCard from "./ScheduleStoryCard";
 
 function Test() {
-  const [schedules, setSchedules] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  const ACCESS_TOKEN = "your_access_token_here"; // 실제 토큰 넣어줘야 함
-
-  useEffect(() => {
-    async function fetchSchedules() {
-      try {
-        const res = await axios.get("/post/list", {
-          headers: {
-            Authorization: `Bearer ${ACCESS_TOKEN}`,
-          },
-          params: {
-            // sorting, filtering 등 필요하면 여기에 넣자
-          },
-        });
-
-        // 응답에서 일정 배열 추출
-        const data = res.data.data || [];
-        setSchedules(data);
-      } catch (err) {
-        console.error("API 불러오기 실패:", err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchSchedules();
-  }, []);
-
-  if (loading) return <div>로딩 중...</div>;
-  if (schedules.length === 0) return <div>일정이 없어요!</div>;
+  const dummySchedule = {
+    id: 1,
+    title: "오로지 내 취향으로만 가득한 여행일정!",
+    likes: 22,
+    bookmarks: 207,
+    isBookmarked: false,
+    isReported: false,
+  };
 
   return (
-    <div className="flex flex-wrap gap-6 justify-center p-6">
-      {schedules.map((item) => (
-        <ScheduleStoryCard key={item.post_id} schedule={item} />
-      ))}
+    <div>
+      <ScheduleStoryCard schedule={dummySchedule} isAdmin={false} />
     </div>
   );
 }

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,18 +1,46 @@
-import ScheduleStoryCard from "./ScheduleStoryCard";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import ScheduleStoryCard from "./ScheduleStoryCard"; // 경로 네가 맞게 수정
 
 function Test() {
-  const dummySchedule = {
-    id: 1,
-    title: "오로지 내 취향으로만 가득한 여행일정!",
-    likes: 22,
-    bookmarks: 207,
-    isBookmarked: false,
-    isReported: false,
-  };
+  const [schedules, setSchedules] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const ACCESS_TOKEN = "your_access_token_here"; // 실제 토큰 넣어줘야 함
+
+  useEffect(() => {
+    async function fetchSchedules() {
+      try {
+        const res = await axios.get("/post/list", {
+          headers: {
+            Authorization: `Bearer ${ACCESS_TOKEN}`,
+          },
+          params: {
+            // sorting, filtering 등 필요하면 여기에 넣자
+          },
+        });
+
+        // 응답에서 일정 배열 추출
+        const data = res.data.data || [];
+        setSchedules(data);
+      } catch (err) {
+        console.error("API 불러오기 실패:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSchedules();
+  }, []);
+
+  if (loading) return <div>로딩 중...</div>;
+  if (schedules.length === 0) return <div>일정이 없어요!</div>;
 
   return (
-    <div>
-      <ScheduleStoryCard schedule={dummySchedule} isAdmin={false} />
+    <div className="flex flex-wrap gap-6 justify-center p-6">
+      {schedules.map((item) => (
+        <ScheduleStoryCard key={item.post_id} schedule={item} />
+      ))}
     </div>
   );
 }

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,23 +1,5 @@
-import ScheduleStoryCard from "./ScheduleStoryCard";
-
 function Test() {
-  const dummySchedule = {
-    post_id: 1,
-    title: "일정스토리의 제목입니다.",
-    start_time: "...",
-    category: "...",
-    is_shared: true,
-    like_count: 500,
-    favorite_count: 200,
-    is_reported: false,
-    is_completed: false,
-  };
-
-  return (
-    <div>
-      <ScheduleStoryCard schedule={dummySchedule} />
-    </div>
-  );
+  return <div>test</div>;
 }
 
 export default Test;


### PR DESCRIPTION
## 📌 제목

- feat: 일정스토리카드 기본UI 구현

## 💡 개요

- 기록했던 일정내용이 기재된 '일정스토리' 카드 

## 📝 상세 내용

- 카드 내부 회색 박스에 등록했던 일정내용 표시되게 할 예정
- 제목 표시 
- 좋아요/찜하기 표시기능 
-기존 dummySchedule컴포넌트를  API 명세서에 기재된 /post/list URL의 Success Response Body 형식으로 수정 후 assets/데이터 폴더에 파일형식으로 이동



## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호
