### PR TITLE
feat: calenar UI 구현 (#13)

### DIFF
--- a/src/components/calendar/DisplayDays.jsx
+++ b/src/components/calendar/DisplayDays.jsx
@@ -1,0 +1,25 @@
+const DisplayDays = () => {
+  const days = [`Sun`, `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`];
+
+  return (
+    <div className="h-[40px] grid grid-cols-7 text-center">
+      {days.map((el) => (
+        <div
+          className={`${
+            el === days[0]
+              ? "text-[#ec4e4e]"
+              : el === days[6]
+              ? "text-[#7892f0]"
+              : "text-black"
+          }
+                        w-[80px] h-[30px]`}
+          key={el}
+        >
+          {el}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DisplayDays;

--- a/src/components/calendar/DisplayWeek.jsx
+++ b/src/components/calendar/DisplayWeek.jsx
@@ -1,0 +1,19 @@
+const DisplayWeek = ({ week }) => {
+  return week.map((el, i) => (
+    <div
+      key={i}
+      className={`${
+        el === week[0]
+          ? "text-[#ec4e4e]"
+          : el === week[6]
+          ? "text-[#7892f0]"
+          : "text-black"
+      } 
+             h-[80px] px-[8px] border-t border-[#393939] truncate`}
+    >
+      <h2 className="h-[30px] text-[15px] flex p-[6px]">{el.date}</h2>
+    </div>
+  ));
+};
+
+export default DisplayWeek;

--- a/src/components/calendar/DisplayWeeks.jsx
+++ b/src/components/calendar/DisplayWeeks.jsx
@@ -2,7 +2,7 @@ import DisplayWeek from "./DisplayWeek";
 
 const DisplayWeeks = ({ weeks }) => {
   return weeks.map((week, i) => (
-    <div key={week + i} className="grid grid-cols-7">
+    <div key={i} className="grid grid-cols-7">
       <DisplayWeek week={week} />
     </div>
   ));

--- a/src/components/calendar/DisplayWeeks.jsx
+++ b/src/components/calendar/DisplayWeeks.jsx
@@ -1,0 +1,11 @@
+import DisplayWeek from "./DisplayWeek";
+
+const DisplayWeeks = ({ weeks }) => {
+  return weeks.map((week, i) => (
+    <div key={week + i} className="grid grid-cols-7">
+      <DisplayWeek week={week} />
+    </div>
+  ));
+};
+
+export default DisplayWeeks;

--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
+import DisplayWeeks from "./DisplayWeeks";
+import DisplayDays from "./DisplayDays";
+
+function MainCalendar() {
+  const [currentDate] = useState(new Date());
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // 매 달 1일
+  const firstDayOfMonth = new Date(year, month, 1);
+
+  // 매 달의 마지막 날 (30일, 31일)
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+
+  const weeks = groupDatesByWeek(firstDayOfMonth, lastDayOfMonth); // 주들을 모을 배열
+
+  return (
+    <>
+      <DisplayDays />
+      <div>
+        <DisplayWeeks weeks={weeks} />
+      </div>
+    </>
+  );
+}
+
+export default MainCalendar;

--- a/src/utils/groupDatesByWeek.jsx
+++ b/src/utils/groupDatesByWeek.jsx
@@ -1,0 +1,41 @@
+export const groupDatesByWeek = (firstDay, lastDay) => {
+  let currentDay = new Date(firstDay);
+  let week = [];
+  const weeks = [];
+  const dayOfFirstDay = firstDay.getDay();
+  const dayOfLastDay = lastDay.getDay();
+
+  if (dayOfFirstDay !== 0) {
+    for (let i = 0; i < dayOfFirstDay; i++) {
+      week.push({
+        month: "",
+        date: "",
+      });
+    }
+  }
+
+  while (currentDay <= lastDay) {
+    week.push({
+      month: currentDay.getMonth() + 1,
+      date: currentDay.getDate(),
+    });
+
+    if (week.length === 7 || currentDay.getDay() === 6) {
+      weeks.push(week);
+      week = [];
+    }
+    currentDay.setDate(currentDay.getDate() + 1);
+  }
+
+  if (week.length > 0) {
+    // 마지막주 처리 (마지막 날이 토요일이 아닐때)
+    for (let i = 6 - dayOfLastDay; i > 0; i--) {
+      week.push({
+        month: "",
+        date: "",
+      });
+    }
+    weeks.push(week);
+  }
+  return weeks;
+};


### PR DESCRIPTION
## 📌 제목

- calendar UI 구현

## 💡 개요

- 달력 UI구현

## 📝 상세 내용

- 이번 달 달력 UI 구현
- grid로 한 열에 7일씩 보이도록 구현

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [x] 테스트 통과

## UI 화면

<img width="1160" height="896" alt="image" src="https://github.com/user-attachments/assets/bd287dd4-aa47-4a10-b1d2-d0b7adcd4951" />


## 🔗 관련 이슈

- close #13 
