### PR TITLE
fix : 버튼 컴포넌트 (#41)

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,37 +1,37 @@
 import React from "react";
 
+const variants = {
+  confirm:
+    "w-[60px] h-7 text-[13px] bg-[#5AA5B2] text-white hover:bg-[#223f43] active:bg-[#223f43] rounded-[9px]",
+  cancel:
+    "w-[60px] h-7 text-[13px] bg-[#d9d9d9] text-gray-700 hover:bg-[#5c5c5c] active:bg-[#5c5c5c] hover:text-white rounded-[9px]",
+  category:
+    "w-auto  text-[14px] h-8 px-3 my-2 bg-[#2F7884] text-white  hover:bg-[#223f43] active:bg-[#223f43] rounded-[9px]",
+  login:
+    "w-[300px] h-10 m-1 bg-[#223f43] text-white hover:bg-[#5AA5B2] rounded-xl",
+};
+
+const baseStyle =
+  "flex justify-center items-center font-semibold transition-colors duration-150 " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#5AA5B2] " +
+  "disabled:opacity-50 disabled:cursor-not-allowed shadow-md";
+
 export const Button = ({
-  cancelText = "취소",
-  confirmText = "저장",
-  onCancelClick,
-  onConfirmClick,
+  variant = "confirm",
+  children,
+  additionalClass = "",
+  type = "button",
+  disabled = false,
+  ...props
 }) => {
   return (
-    <div className="flex gap-3 justify-center my-3">
-      <button
-        className="rounded-lg px-6 py-2 text-sm font-bold bg-[#FFE6AB] hover:bg-[#ffb400]"
-        onClick={onCancelClick}
-      >
-        {cancelText}
-      </button>
-      <button
-        className="rounded-lg px-6 py-2 text-sm font-bold bg-[#CAE8F2] hover:bg-[#5aa5b2]"
-        onClick={onConfirmClick}
-      >
-        {confirmText}
-      </button>
-      {/* <button
-        className="rounded-lg px-6 py-2 text-sm font-bold bg-[#f5f5f5] hover:bg-[#d9d9d9]"
-        onClick={onCancelClick}
-      >
-        {cancelText}
-      </button>
-      <button
-        className="rounded-lg px-6 py-2 text-sm font-bold bg-[#CAE8F2] hover:bg-[#5aa5b2]"
-        onClick={onConfirmClick}
-      >
-        {confirmText}
-      </button> */}
-    </div>
+    <button
+      type={type}
+      disabled={disabled}
+      className={`${baseStyle} ${variants[variant]} ${additionalClass}`}
+      {...props}
+    >
+      {children}
+    </button>
   );
 };

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,5 +1,35 @@
+import { Button } from "./Button";
+
 function Test() {
-  return <div>text</div>;
+  return (
+    <div className="m-3 gap-2">
+      {/* text */}
+      <div className="flex flex-row gap-2">
+        <Button variant="cancel" size="s">
+          취소
+        </Button>
+        <Button variant="confirm" size="s">
+          저장
+        </Button>
+      </div>
+      <div className="flex flex-row gap-2">
+        <Button variant="category" size="s">
+          카테고리
+        </Button>
+        <Button variant="category" size="s">
+          우선순위
+        </Button>
+        <Button variant="category" size="s">
+          공유
+        </Button>
+        <Button variant="category" size="s">
+          반복
+        </Button>
+      </div>
+      <Button variant="login">로그인</Button>
+      <Button variant="login">가입하기</Button>
+    </div>
+  );
 }
 
 export default Test;

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,35 +1,5 @@
-import { Button } from "./Button";
-
 function Test() {
-  return (
-    <div className="m-3 gap-2">
-      {/* text */}
-      <div className="flex flex-row gap-2">
-        <Button variant="cancel" size="s">
-          취소
-        </Button>
-        <Button variant="confirm" size="s">
-          저장
-        </Button>
-      </div>
-      <div className="flex flex-row gap-2">
-        <Button variant="category" size="s">
-          카테고리
-        </Button>
-        <Button variant="category" size="s">
-          우선순위
-        </Button>
-        <Button variant="category" size="s">
-          공유
-        </Button>
-        <Button variant="category" size="s">
-          반복
-        </Button>
-      </div>
-      <Button variant="login">로그인</Button>
-      <Button variant="login">가입하기</Button>
-    </div>
-  );
+  return <div>text</div>;
 }
 
 export default Test;


### PR DESCRIPTION
## 📌 제목

- 버튼 공통 컴포넌트

## 💡 개요

- 다양한 상황에서 필요한 버튼을 재사용가능하게 수정

## 📝 상세 내용

- confirm / cancel / category / login 등의 버튼으로 사용가능
- additionalClass 를 추가해서 이후 className을 작성가능
- props 연결

## ✅ 체크리스트

- [x] lint 검사 통과
- [x] 테스트 통과

## 🔗 관련 이슈

- #41 
- 
<img width="380" height="207" alt="스크린샷 2025-09-18 오전 11 19 51" src="https://github.com/user-attachments/assets/6508b524-3e56-44a9-989a-6398a9d72544" />
