### PR TITLE
feat:일정상세카드 기능구현(#12)

### DIFF
--- a/src/components/DetailScheduleCard.jsx
+++ b/src/components/DetailScheduleCard.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useRef } from "react";
+
+function DetailScheduleCard({
+  title,
+  description,
+  onChangeTitle,
+  onChangeDescription,
+}) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isEditingDesc, setIsEditingDesc] = useState(false);
+  const [editTitle, setEditTitle] = useState(title);
+  const [editDesc, setEditDesc] = useState(description);
+
+  const descInputRef = useRef(null);
+
+  const onTitleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      setIsEditingTitle(false);
+      setIsEditingDesc(true);
+      setTimeout(() => {
+        descInputRef.current?.focus();
+      }, 0);
+    }
+  };
+
+  const finishTitleEdit = () => {
+    setIsEditingTitle(false);
+    onChangeTitle(editTitle);
+  };
+
+  const finishDescEdit = () => {
+    setIsEditingDesc(false);
+    onChangeDescription(editDesc);
+  };
+
+  return (
+    <div
+      className="bg-gray-200 rounded-md p-3 ml-4 shadow-sm relative flex flex-col"
+      style={{ minWidth: "200px", maxWidth: "90vw", whiteSpace: "nowrap" }}
+    >
+      {/* 수정 아이콘 */}
+      <button
+        type="button"
+        onClick={() => setIsEditingTitle(true)}
+        className="absolute top-2 right-2 text-gray-600 hover:text-gray-900"
+        aria-label="수정"
+        title="수정"
+      >
+        ✎
+      </button>
+
+      {/* 제목 */}
+      {isEditingTitle ? (
+        <input
+          value={editTitle}
+          onChange={(e) => setEditTitle(e.target.value)}
+          onBlur={finishTitleEdit}
+          onKeyDown={onTitleKeyDown}
+          className="w-full mb-2 border border-gray-400 rounded px-2 py-1"
+          autoFocus
+          style={{ whiteSpace: "normal" }}
+        />
+      ) : (
+        <h4
+          className="font-bold mb-1 cursor-text inline-block"
+          tabIndex={0}
+          onClick={() => setIsEditingTitle(true)}
+          onKeyDown={(e) => e.key === "Enter" && setIsEditingTitle(true)}
+        >
+          {editTitle}
+        </h4>
+      )}
+
+      {/* 내용 */}
+      {isEditingDesc ? (
+        <textarea
+          ref={descInputRef}
+          value={editDesc}
+          onChange={(e) => setEditDesc(e.target.value)}
+          onBlur={finishDescEdit}
+          rows={1}
+          className="border border-gray-400 rounded px-2 py-1 resize-none"
+          style={{ whiteSpace: "normal", overflow: "auto" }}
+          autoFocus
+        />
+      ) : (
+        <p
+          className="text-sm text-gray-700 cursor-text inline-block overflow-x-auto"
+          style={{ whiteSpace: "nowrap" }}
+          onClick={() => setIsEditingDesc(true)}
+        >
+          {editDesc}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default DetailScheduleCard;

--- a/src/components/DetailScheduleCard.jsx
+++ b/src/components/DetailScheduleCard.jsx
@@ -1,97 +1,34 @@
-import React, { useState, useRef } from "react";
+import React from "react";
+import { FaPen } from "react-icons/fa6";
 
-function DetailScheduleCard({
-  title,
-  description,
-  onChangeTitle,
-  onChangeDescription,
-}) {
-  const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [isEditingDesc, setIsEditingDesc] = useState(false);
-  const [editTitle, setEditTitle] = useState(title);
-  const [editDesc, setEditDesc] = useState(description);
-
-  const descInputRef = useRef(null);
-
-  const onTitleKeyDown = (e) => {
-    if (e.key === "Enter") {
-      setIsEditingTitle(false);
-      setIsEditingDesc(true);
-      setTimeout(() => {
-        descInputRef.current?.focus();
-      }, 0);
-    }
-  };
-
-  const finishTitleEdit = () => {
-    setIsEditingTitle(false);
-    onChangeTitle(editTitle);
-  };
-
-  const finishDescEdit = () => {
-    setIsEditingDesc(false);
-    onChangeDescription(editDesc);
+function DetailScheduleCard({ title, description }) {
+  const handlePenClick = () => {
+    console.log("펜 아이콘 눌렸지만 기능은 없음");
   };
 
   return (
     <div
-      className="bg-gray-200 rounded-md p-3 ml-4 shadow-sm relative flex flex-col"
-      style={{ minWidth: "200px", maxWidth: "90vw", whiteSpace: "nowrap" }}
+      className="bg-gray-200 rounded-md p-3 ml-4 shadow-sm relative inline-flex flex-col max-w-[90vw] overflow-x-auto"
+      style={{ width: "fit-content" }}
     >
-      {/* 수정 아이콘 */}
+      {/* 수정 아이콘 오른쪽 상단 고정 */}
       <button
         type="button"
-        onClick={() => setIsEditingTitle(true)}
+        onClick={handlePenClick}
         className="absolute top-2 right-2 text-gray-600 hover:text-gray-900"
-        aria-label="수정"
-        title="수정"
+        aria-label="정보 수정"
+        title="정보 수정"
       >
-        ✎
+        <FaPen size={16} />
       </button>
 
       {/* 제목 */}
-      {isEditingTitle ? (
-        <input
-          value={editTitle}
-          onChange={(e) => setEditTitle(e.target.value)}
-          onBlur={finishTitleEdit}
-          onKeyDown={onTitleKeyDown}
-          className="w-full mb-2 border border-gray-400 rounded px-2 py-1"
-          autoFocus
-          style={{ whiteSpace: "normal" }}
-        />
-      ) : (
-        <h4
-          className="font-bold mb-1 cursor-text inline-block"
-          tabIndex={0}
-          onClick={() => setIsEditingTitle(true)}
-          onKeyDown={(e) => e.key === "Enter" && setIsEditingTitle(true)}
-        >
-          {editTitle}
-        </h4>
-      )}
+      <h1 className="font-bold mb-1 pr-8 whitespace-nowrap">{title}</h1>
 
       {/* 내용 */}
-      {isEditingDesc ? (
-        <textarea
-          ref={descInputRef}
-          value={editDesc}
-          onChange={(e) => setEditDesc(e.target.value)}
-          onBlur={finishDescEdit}
-          rows={1}
-          className="border border-gray-400 rounded px-2 py-1 resize-none"
-          style={{ whiteSpace: "normal", overflow: "auto" }}
-          autoFocus
-        />
-      ) : (
-        <p
-          className="text-sm text-gray-700 cursor-text inline-block overflow-x-auto"
-          style={{ whiteSpace: "nowrap" }}
-          onClick={() => setIsEditingDesc(true)}
-        >
-          {editDesc}
-        </p>
-      )}
+      <p className="text-sm text-gray-700 pr-8 whitespace-nowrap">
+        {description}
+      </p>
     </div>
   );
 }

--- a/src/components/TimeCard.jsx
+++ b/src/components/TimeCard.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function TimeCard({ time }) {
+  return (
+    <div className="w-24 bg-gray-200 rounded-md text-center py-1 text-sm font-medium text-gray-700 select-none flex items-center justify-center">
+      {time}
+    </div>
+  );
+}
+
+export default TimeCard;


### PR DESCRIPTION
## 📌 제목

- feat:일정상세카드 기능구현(#12)

## 💡 개요


- 일정상세카드 UI 및 기능구현

## 📝 상세 내용
- 수정 아이콘 클릭만 가능(기능안넣음)
- 텍스트가 길어지면 카드가 옆으로 늘어남
- 





## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호

