### PR TITLE
feat: 메인페이지 생성 (#19)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,9 @@
-import { Layout } from "./components/Layout.jsx";
+import Layout from "./components/Layout.jsx";
 
 function App() {
   return (
     <>
-      <Test />
+      <Layout />
     </>
   );
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -6,7 +6,7 @@ const Layout = () => {
   return (
     <div>
       <Header />
-      <div>
+      <div className="flex">
         <MenuBar />
         <Outlet />
       </div>

--- a/src/components/calendar/DisplayWeek.jsx
+++ b/src/components/calendar/DisplayWeek.jsx
@@ -9,7 +9,7 @@ const DisplayWeek = ({ week }) => {
           ? "text-[#7892f0]"
           : "text-black"
       } 
-             h-[80px] px-[8px] border-t border-[#393939] truncate`}
+             h-[102px] px-[8px] border-t border-[#393939] truncate`}
     >
       <h2 className="h-[30px] text-[15px] flex p-[6px]">{el.date}</h2>
     </div>

--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
 import DisplayWeeks from "./DisplayWeeks";
 import DisplayDays from "./DisplayDays";
@@ -8,6 +7,7 @@ const MainCalendar = () => {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
+function MainCalendar({ year, month }) {
   // 매 달 1일
   const firstDayOfMonth = new Date(year, month, 1);
 

--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -2,11 +2,6 @@ import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
 import DisplayWeeks from "./DisplayWeeks";
 import DisplayDays from "./DisplayDays";
 
-const MainCalendar = () => {
-  const [currentDate] = useState(new Date());
-  const year = currentDate.getFullYear();
-  const month = currentDate.getMonth();
-
 function MainCalendar({ year, month }) {
   // 매 달 1일
   const firstDayOfMonth = new Date(year, month, 1);
@@ -22,6 +17,6 @@ function MainCalendar({ year, month }) {
       <DisplayWeeks weeks={weeks} />
     </div>
   );
-};
+}
 
 export default MainCalendar;

--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -17,12 +17,10 @@ const MainCalendar = () => {
   const weeks = groupDatesByWeek(firstDayOfMonth, lastDayOfMonth); // 주들을 모을 배열
 
   return (
-    <>
+    <div className="w-[calc(100vw-200px)] p-5">
       <DisplayDays />
-      <div>
-        <DisplayWeeks weeks={weeks} />
-      </div>
-    </>
+      <DisplayWeeks weeks={weeks} />
+    </div>
   );
 };
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,7 +16,7 @@ let router = createBrowserRouter([
     Component: App,
     children: [
       {
-        path: "/calendar",
+        path: "/",
         Component: Main,
       },
       {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import TestH from "./test/TestH";
 import TestD from "./test/TestD";
 import TestJ from "./test/TestJ";
 import TestL from "./test/TestL";
+import Main from "./pages/Main";
 
 let router = createBrowserRouter([
   {
@@ -16,6 +17,7 @@ let router = createBrowserRouter([
     children: [
       {
         path: "/calendar",
+        Component: Main,
       },
       {
         path: "/schedule",

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -2,21 +2,25 @@ import { useState } from "react";
 import MainCalendar from "../components/calendar/MainCalendar";
 import { MdOutlineNavigateNext } from "react-icons/md";
 import { MdOutlineNavigateBefore } from "react-icons/md";
+import { Button } from "../components/Button";
 
-function Main() {
+const Main = () => {
   const [currentDate] = useState(new Date());
   const thisYear = currentDate.getFullYear();
   const thisMonth = currentDate.getMonth() + 1;
 
   return (
     <div className="h-[calc(100vh-100.18px)]">
-      <div className="flex items-center gap-5 p-[28px_0_18px_28px] text-2xl font-extrabold">
-        {thisYear}.{thisMonth}
-        <MdOutlineNavigateBefore />
-        <MdOutlineNavigateNext />
+      <div className="flex items-center justify-between px-8">
+        <div className="flex items-center gap-5 p-[28px_0_18px_0] text-2xl font-extrabold">
+          {thisYear}.{thisMonth}
+          <MdOutlineNavigateBefore />
+          <MdOutlineNavigateNext />
+        </div>
+        <Button children={"오늘"} />
       </div>
       <MainCalendar year={thisYear} month={thisMonth} />
     </div>
   );
-}
+};
 export default Main;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,10 +1,22 @@
+import { useState } from "react";
 import MainCalendar from "../components/calendar/MainCalendar";
+import { MdOutlineNavigateNext } from "react-icons/md";
+import { MdOutlineNavigateBefore } from "react-icons/md";
 
 function Main() {
+  const [currentDate] = useState(new Date());
+  const thisYear = currentDate.getFullYear();
+  const thisMonth = currentDate.getMonth() + 1;
+
   return (
-    <>
-      <MainCalendar />
-    </>
+    <div className="h-[calc(100vh-100.18px)]">
+      <div className="flex items-center gap-5 p-[28px_0_18px_28px] text-2xl font-extrabold">
+        {thisYear}.{thisMonth}
+        <MdOutlineNavigateBefore />
+        <MdOutlineNavigateNext />
+      </div>
+      <MainCalendar year={thisYear} month={thisMonth} />
+    </div>
   );
 }
 export default Main;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,0 +1,10 @@
+import MainCalendar from "../components/calendar/MainCalendar";
+
+function Main() {
+  return (
+    <>
+      <MainCalendar />
+    </>
+  );
+}
+export default Main;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import MainCalendar from "../components/calendar/MainCalendar";
 import { MdOutlineNavigateNext } from "react-icons/md";
 import { MdOutlineNavigateBefore } from "react-icons/md";
-import { Button } from "../components/Button";
+import Button from "../components/Button";
 
 const Main = () => {
   const [currentDate] = useState(new Date());

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
 import MainCalendar from "../components/calendar/MainCalendar";
 import { MdOutlineNavigateNext } from "react-icons/md";
 import { MdOutlineNavigateBefore } from "react-icons/md";
 import Button from "../components/Button";
 
 const Main = () => {
-  const [currentDate] = useState(new Date());
+  const currentDate = new Date();
   const thisYear = currentDate.getFullYear();
   const thisMonth = currentDate.getMonth() + 1;
 


### PR DESCRIPTION
## 📌 제목

- feat: 메인페이지 생성 (#19)

## 💡 개요

- 메인페이지 캘린더 UI

## 📝 상세 내용

- 캘린더 메인페이지에 UI 렌더링
- 년도, 월 표기
- 전 달, 다음달 버튼 아이콘 배치

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 화면UI

<img width="963" height="771" alt="image" src="https://github.com/user-attachments/assets/8c0e5cf1-b5cd-4c13-9ccf-b5566bddb879" />


## 🔗 관련 이슈

- close #19 
