### PR TITLE
feat: test 컴포넌트 생성 및 export default로 통일 (#61)

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -16,7 +16,7 @@ const baseStyle =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#5AA5B2] " +
   "disabled:opacity-50 disabled:cursor-not-allowed shadow-md";
 
-export const Button = ({
+const Button = ({
   variant = "confirm",
   children,
   additionalClass = "",
@@ -35,3 +35,5 @@ export const Button = ({
     </button>
   );
 };
+
+export default Button;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import { IoSearch } from "react-icons/io5";
 import { IoMdNotifications } from "react-icons/io";
 import { FaCircleUser } from "react-icons/fa6";
 
-export const Header = () => {
+const Header = () => {
   return (
     <div>
       <header className="flex items-center justify-between flex-row mx-10 my-3">
@@ -19,3 +19,5 @@ export const Header = () => {
     </div>
   );
 };
+
+export default Header;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router";
-import { Header } from "./Header";
+import Header from "./Header";
 import MenuBar from "./MenuBar";
 
 const Layout = () => {

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router";
 import { Header } from "./Header";
 import MenuBar from "./MenuBar";
 
-export const Layout = () => {
+const Layout = () => {
   return (
     <div>
       <Header />
@@ -13,3 +13,5 @@ export const Layout = () => {
     </div>
   );
 };
+
+export default Layout;

--- a/src/components/ScheduleCard.jsx
+++ b/src/components/ScheduleCard.jsx
@@ -22,7 +22,7 @@ const getColor = (priority) => {
   }
 };
 
-export const ScheduleCard = () => {
+const ScheduleCard = () => {
   // const post = props.post;
 
   return (
@@ -67,3 +67,5 @@ export const ScheduleCard = () => {
     </div>
   );
 };
+
+export default ScheduleCard;

--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -3,7 +3,7 @@ import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
 import DisplayWeeks from "./DisplayWeeks";
 import DisplayDays from "./DisplayDays";
 
-function MainCalendar() {
+const MainCalendar = () => {
   const [currentDate] = useState(new Date());
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
@@ -24,6 +24,6 @@ function MainCalendar() {
       </div>
     </>
   );
-}
+};
 
 export default MainCalendar;

--- a/src/constants/errorMessage.jsx
+++ b/src/constants/errorMessage.jsx
@@ -1,3 +1,3 @@
-export const errorMessage = {
+export const ERROR_MESSAGE = {
   email: "유효하지 않은 이메일입니다.",
 };

--- a/src/constants/regExp.jsx
+++ b/src/constants/regExp.jsx
@@ -1,4 +1,4 @@
-export const regExp = {
+export const REG_EXP = {
   email: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
   password: "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,20}$",
   name: "^(?:[a-zA-Z]{10,20}|[가-힣]{2,10})$",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,10 @@ import App from "./App";
 import "./index.css";
 import Login from "./pages/Login";
 import Signin from "./pages/Signin";
+import TestH from "./test/TestH";
+import TestD from "./test/TestD";
+import TestJ from "./test/TestJ";
+import TestL from "./test/TestL";
 
 let router = createBrowserRouter([
   {
@@ -46,15 +50,19 @@ let router = createBrowserRouter([
   },
   {
     path: "/testH",
+    Component: TestH,
   },
   {
     path: "/testD",
+    Component: TestD,
   },
   {
     path: "/testJ",
+    Component: TestJ,
   },
   {
     path: "/testL",
+    Component: TestL,
   },
 ]);
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,7 +7,7 @@ import kakaoLogo from "../assets/kakao.png";
 import { Link } from "react-router";
 import { Button } from "../components/Button";
 
-function Login() {
+const Login = () => {
   const [emailInputValue, setEmailInputValue] = useState("");
   const [passwordInputValue, setPasswordInputValue] = useState("");
 
@@ -67,6 +67,6 @@ function Login() {
       </p>
     </div>
   );
-}
+};
 
 export default Login;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,7 +5,7 @@ import googleLogo from "../assets/google.png";
 import naverLogo from "../assets/naver.png";
 import kakaoLogo from "../assets/kakao.png";
 import { Link } from "react-router";
-import { Button } from "../components/Button";
+import Button from "../components/Button";
 
 const Login = () => {
   const [emailInputValue, setEmailInputValue] = useState("");

--- a/src/pages/Signin.jsx
+++ b/src/pages/Signin.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 import logo from "../assets/Logo.svg";
 import { Button } from "../components/Button";
 
-function Signin() {
+const Signin = () => {
   const [nameInputValue, setNameInputValue] = useState("");
   const [emailInputValue, setEmailInputValue] = useState("");
   const [passwordInputValue, setPasswordInputValue] = useState("");
@@ -72,6 +72,6 @@ function Signin() {
       </p>
     </div>
   );
-}
+};
 
 export default Signin;

--- a/src/pages/Signin.jsx
+++ b/src/pages/Signin.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import Input from "../components/Input";
 import { Link } from "react-router";
 import logo from "../assets/Logo.svg";
-import { Button } from "../components/Button";
+import Button from "../components/Button";
 
 const Signin = () => {
   const [nameInputValue, setNameInputValue] = useState("");

--- a/src/test/TestD.jsx
+++ b/src/test/TestD.jsx
@@ -1,0 +1,4 @@
+function TestD() {
+  return <div>단비의 테스트 페이지</div>;
+}
+export default TestD;

--- a/src/test/TestH.jsx
+++ b/src/test/TestH.jsx
@@ -1,0 +1,4 @@
+function TestH() {
+  return <div>혜림의 테스트 페이지</div>;
+}
+export default TestH;

--- a/src/test/TestJ.jsx
+++ b/src/test/TestJ.jsx
@@ -1,0 +1,4 @@
+function TestJ() {
+  return <div>종원의 테스트 페이지</div>;
+}
+export default TestJ;

--- a/src/test/TestL.jsx
+++ b/src/test/TestL.jsx
@@ -1,0 +1,4 @@
+function TestL() {
+  return <div>지호의 테스트 페이지</div>;
+}
+export default TestL;


### PR DESCRIPTION
## 📌 제목

- feat: test 컴포넌트 생성 및 export default로 통일 (#61)

## 💡 개요

- test 컴포넌트 생성 및 라우팅 연결

## 📝 상세 내용

- 팀원 별 test 컴포넌트 생성 및 라우팅 연결
- 컴포넌트 export default로 통일

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [x] 테스트 통과

## 🔗 관련 이슈

- close #61 
