### PR TITLE
[feat] + 버튼(새로운일정추가) 생성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import Layout from "./components/Layout.jsx";
 function App() {
   return (
     <>
-      <Test />
+      <Layout />
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Layout } from "./components/Layout.jsx";
+import Layout from "./components/Layout.jsx";
 
 function App() {
   return (

--- a/src/components/PlusButton.jsx
+++ b/src/components/PlusButton.jsx
@@ -1,0 +1,11 @@
+import { BsCalendarPlus } from "react-icons/bs";
+
+const PlusButton = () => {
+  return (
+    <div>
+      <BsCalendarPlus />
+    </div>
+  );
+};
+
+export default PlusButton;

--- a/src/components/PlusButton.jsx
+++ b/src/components/PlusButton.jsx
@@ -1,12 +1,6 @@
 import { BsCalendarPlus } from "react-icons/bs";
 
-const PlusButton = ({
-  onClick,
-  size = 32,
-  title = "일정 추가",
-  className = "",
-  disabled = false,
-}) => {
+const PlusButton = ({ onClick, title = "일정 추가", disabled = false }) => {
   return (
     <button
       type="button"
@@ -15,11 +9,10 @@ const PlusButton = ({
       disabled={disabled}
       className={`group fixed right-4 bottom-4 z-50
                   inline-flex items-center justify-center
-                  w-12 h-12 text-[#223F43]
-                  ${className}`}
+                  w-12 h-12 text-[#223F43]`}
     >
       <BsCalendarPlus
-        size={size}
+        size={32}
         className="transition-transform duration-150 group-hover:scale-110"
       />
     </button>

--- a/src/components/PlusButton.jsx
+++ b/src/components/PlusButton.jsx
@@ -2,7 +2,7 @@ import { BsCalendarPlus } from "react-icons/bs";
 
 const PlusButton = ({
   onClick,
-  size = 22,
+  size = 32,
   title = "일정 추가",
   className = "",
   disabled = false,
@@ -13,13 +13,15 @@ const PlusButton = ({
       onClick={onClick}
       title={title}
       disabled={disabled}
-      className={`inline-flex items-center justify-center rounded-full p-2
-                  shadow-md hover:shadow-lg transition
-                  bg-white hover:bg-gray-50
-                  disabled:opacity-50 disabled:cursor-not-allowed
+      className={`group fixed right-4 bottom-4 z-50
+                  inline-flex items-center justify-center
+                  w-12 h-12 text-[#223F43]
                   ${className}`}
     >
-      <BsCalendarPlus size={size} />
+      <BsCalendarPlus
+        size={size}
+        className="transition-transform duration-150 group-hover:scale-110"
+      />
     </button>
   );
 };

--- a/src/components/PlusButton.jsx
+++ b/src/components/PlusButton.jsx
@@ -1,10 +1,26 @@
 import { BsCalendarPlus } from "react-icons/bs";
 
-const PlusButton = () => {
+const PlusButton = ({
+  onClick,
+  size = 22,
+  title = "일정 추가",
+  className = "",
+  disabled = false,
+}) => {
   return (
-    <div>
-      <BsCalendarPlus />
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      disabled={disabled}
+      className={`inline-flex items-center justify-center rounded-full p-2
+                  shadow-md hover:shadow-lg transition
+                  bg-white hover:bg-gray-50
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                  ${className}`}
+    >
+      <BsCalendarPlus size={size} />
+    </button>
   );
 };
 

--- a/src/components/test.jsx
+++ b/src/components/test.jsx
@@ -1,4 +1,0 @@
-function Test() {
-  return <div>test</div>;
-}
-export default Test;

--- a/src/test/TestD.jsx
+++ b/src/test/TestD.jsx
@@ -1,11 +1,15 @@
-import Layout from "../components/Layout";
+import Header from "../components/Header";
+import MenuBar from "../components/MenuBar";
 import PlusButton from "../components/PlusButton";
 
 function TestD() {
   return (
     <div>
-      <Layout />
-      <PlusButton />
+      <Header />
+      <div className="flex">
+        <MenuBar />
+        <PlusButton />
+      </div>
     </div>
   );
 }

--- a/src/test/TestD.jsx
+++ b/src/test/TestD.jsx
@@ -1,4 +1,12 @@
+import Layout from "../components/Layout";
+import PlusButton from "../components/PlusButton";
+
 function TestD() {
-  return <div>단비의 테스트 페이지</div>;
+  return (
+    <div>
+      <Layout />
+      <PlusButton />
+    </div>
+  );
 }
 export default TestD;


### PR DESCRIPTION
## 📌 제목

- + 버튼(새로운일정추가) 생성

## 💡 개요

- 어느 페이지든지 + 버튼보일 수 있게 공통컴포넌트로 제작 
 
## 📝 상세 내용

- + 버튼 아이콘 추가
- props로 연결
- + 버튼 스타일 지정

## ✅ 체크리스트

- [ ] lint 검사 통과
- [ ] 테스트 통과


## 🔗 관련 이슈

- #63

<img width="1502" height="818" alt="스크린샷 2025-09-19 오전 11 05 33" src="https://github.com/user-attachments/assets/dece01fc-2bef-4659-beff-43495304d589" />
