### PR TITLE
feat: routineCard 생성(#69)

### DIFF
--- a/src/components/RoutineCard.jsx
+++ b/src/components/RoutineCard.jsx
@@ -1,0 +1,46 @@
+import { FaUser } from "react-icons/fa6";
+import { IoShare } from "react-icons/io5";
+import { FaCheckSquare, FaRegSquare } from "react-icons/fa";
+import { TbTrash } from "react-icons/tb";
+import { getColorOfPriority } from "../utils/getColorOfPriority";
+
+const RoutineCard = ({ post }) => {
+  const { priority, start_time, is_shared, title, is_completed } = post;
+  const priorityColor = getColorOfPriority(priority);
+
+  return (
+    <div
+      className={`flex items-center gap-4 border-l-4 ${priorityColor} pl-3 py-2`}
+    >
+      {/* 왼쪽: 날짜 + 아이콘 */}
+      <div className="flex flex-col items-start min-w-[140px]">
+        <p className="text-l font-bold text-gray-700 flex items-center gap-2">
+          {start_time ? new Date(start_time).toLocaleDateString("ko-KR") : "-"}
+          {is_shared ? (
+            <IoShare className="text-gray-500" />
+          ) : (
+            <FaUser className="text-gray-500" />
+          )}
+        </p>
+        <p className="text-sm text-[#C2C2C2]">반복주기</p>
+      </div>
+
+      {/* 오른쪽: 일정 내용 */}
+      <div className="flex w-full justify-between items-center gap-4">
+        <div className="flex flex-col items-start justify-start p-3 px-6 gap-2 bg-white rounded-xl shadow-sm w-full">
+          <div className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+            {is_completed ? <FaCheckSquare /> : <FaRegSquare />}
+            <span>{title}</span>
+          </div>
+        </div>
+
+        <TbTrash
+          size={30}
+          className="cursor-pointer text-[#d9d9d9] hover:text-[#5C5C5C]"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default RoutineCard;

--- a/src/test/TestH.jsx
+++ b/src/test/TestH.jsx
@@ -1,4 +1,13 @@
+import { posts } from "../assets/data/dummyPostList";
+import RoutineCard from "../components/RoutineCard";
+
 function TestH() {
-  return <div>혜림의 테스트 페이지</div>;
+  return (
+    <div>
+      {posts.data.map((el) => (
+        <RoutineCard key={el.post_id} post={el} />
+      ))}
+    </div>
+  );
 }
 export default TestH;

--- a/src/utils/getColorOfPriority.jsx
+++ b/src/utils/getColorOfPriority.jsx
@@ -1,0 +1,16 @@
+export const getColorOfPriority = (priority) => {
+  switch (priority) {
+    case "긴급":
+      return "border-red-500";
+    case "상":
+      return "border-orange-400";
+    case "중":
+      return "border-yellow-400";
+    case "하":
+      return "border-green-400";
+    case "보류":
+      return "border-blue-300";
+    default:
+      return "border-gray-200";
+  }
+};


### PR DESCRIPTION
## 📌 제목

- feat: routineCard 생성(#69)

## 💡 개요

- 재사용가능한 루틴카드 (루틴리스트에서 사용)

## 📝 상세 내용

- 루틴 리스트에서 사용되는 루틴카드 UI

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [x] 테스트 통과

## 🔗 관련 이슈

- close #69 
