### PR TITLE
feat: 일정스토리 페이지 생성(#28)

### DIFF
--- a/src/assets/data/dummyPostList.js
+++ b/src/assets/data/dummyPostList.js
@@ -1,5 +1,5 @@
 export const posts = {
-  post_count: 4,
+  schedule_count: 4,
   data: [
     {
       id: 1,

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -8,7 +8,7 @@ import { BiSolidUserRectangle } from "react-icons/bi";
 const MenuBar = () => {
   return (
     <>
-      <nav className="w-[200px] h-[calc(100vh-100.18px)] p-9 border-r border-[#D9D9D9]">
+      <nav className="min-w-[200px] p-9 border-r border-[#D9D9D9]">
         <ul className="flex flex-col justify-center items-start gap-10 text-xl">
           <li className="flex gap-2 items-center">
             <FaRegCalendarAlt />
@@ -31,7 +31,7 @@ const MenuBar = () => {
           </li>
         </ul>
       </nav>
-      {/* <nav className="w-[200px] h-screen p-9 border-r border-[#D9D9D9]">
+      {/* <nav className="min-w-[200px] p-9 border-r border-[#D9D9D9]">
         <ul className="flex flex-col justify-center items-start gap-10 text-xl">
           <li className="flex gap-2 items-center">
             <BiSolidUserRectangle />

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -18,7 +18,7 @@ function ScheduleStoryCard({ schedule }) {
       {/* 좋아요 & 찜하기 */}
       <div className="flex space-x-6 text-gray-600 text-sm font-medium justify-center">
         <div> 좋아요: {schedule.like_count ?? 0}</div>
-        <div> 찜하기: {schedule.favorite_count ?? 0}</div>
+        <div> 찜하기: {schedule.bookmark_count ?? 0}</div>
       </div>
     </div>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ import Main from "./pages/Main";
 import DailyPage from "./pages/DailyPage";
 import Search from "./pages/Search";
 import Routine from "./pages/Routine";
+import ScheduleStory from "./pages/ScheduleStory";
 
 let router = createBrowserRouter([
   {
@@ -34,7 +35,8 @@ let router = createBrowserRouter([
         path: "/someday",
       },
       {
-        path: "/share_schedule",
+        path: "/schedule_story",
+        Component: ScheduleStory,
       },
       {
         path: "/search",

--- a/src/pages/ScheduleStory.jsx
+++ b/src/pages/ScheduleStory.jsx
@@ -10,12 +10,12 @@ const ScheduleStory = () => {
       </div>
 
       <div className="text-sm p-4 border-t border-gray-200 pb-2">
-        <p>전체 : {posts.post_count}</p>
+        <p>전체 : {posts.schedule_count}</p>
       </div>
 
       <div className="flex flex-wrap justify-center items-center gap-2">
         {posts.data.map((post) => (
-          <div key={post.post_id} className="py-4">
+          <div key={post.id} className="py-4">
             <ScheduleStoryCard schedule={post} />
           </div>
         ))}

--- a/src/pages/ScheduleStory.jsx
+++ b/src/pages/ScheduleStory.jsx
@@ -1,0 +1,27 @@
+import { posts } from "../assets/data/dummyPostList";
+import FilterButtons from "../components/FilterButtons";
+import ScheduleStoryCard from "../components/ScheduleStoryCard";
+
+const ScheduleStory = () => {
+  return (
+    <div className="w-full flex flex-col p-4">
+      <div className="flex flex-row gap-3 mb-4">
+        <FilterButtons keys={["category", "latest", "priority"]} />
+      </div>
+
+      <div className="text-sm p-4 border-t border-gray-200 pb-2">
+        <p>전체 : {posts.post_count}</p>
+      </div>
+
+      <div className="flex flex-wrap justify-center items-center gap-2">
+        {posts.data.map((post) => (
+          <div key={post.post_id} className="py-4">
+            <ScheduleStoryCard schedule={post} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleStory;


### PR DESCRIPTION
## 📌 제목

- feat: 일정스토리 페이지 생성(#28)

## 💡 개요

- 일정 스토리 페이지 UI

## 📝 상세 내용

- 일정 스토리 페이지 UI
- 일정 스토리 카드를 이용하여 렌더링

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [x] 테스트 통과

## 화면 UI

<img width="942" height="772" alt="image" src="https://github.com/user-attachments/assets/2206beeb-9260-477c-92a7-1bceccecb97a" />


## 🔗 관련 이슈

- close #28 
