### PR TITLE
[feat] TabButton을 컴포넌트로 재사용가능하게 분리(#75)

### DIFF
--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -1,17 +1,7 @@
 import { useState } from "react";
 
 const TabButton = ({
-  tabs = [
-    "전체",
-    "내가작성글",
-    "일정스토리",
-    "완료된일",
-    "해야할일",
-    "할일",
-    "루틴",
-    "언젠가",
-    "일정스토리",
-  ],
+  tabs = ["전체", "완료된일", "해야할일"],
   defaultTab = "전체",
   onTabChange = null,
 }) => {

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+const TabButton = ({
+  tabs = [
+    "전체",
+    "내가작성글",
+    "일정스토리",
+    "완료된일",
+    "해야할일",
+    "할일",
+    "루틴",
+    "언젠가",
+    "일정스토리",
+  ],
+  defaultTab = "전체",
+  onTabChange = null,
+}) => {
+  const [activeTab, setActiveTab] = useState(defaultTab);
+
+  const handleTabClick = (tab) => {
+    setActiveTab(tab);
+    if (onTabChange) {
+      onTabChange(tab);
+    }
+  };
+
+  return (
+    <div className="w-full min-h-screen bg-gray-50">
+      <div className={`bg-white border-b border-gray-200`}>
+        <div className="flex">
+          {tabs.map((tab, index) => (
+            <button
+              key={`${tab}-${index}`}
+              onClick={() => handleTabClick(tab)}
+              className={`px-6 py-4 text-sm border-b-3 border-gray-200 transition-colors ${
+                activeTab === tab
+                  ? "text-gray-800 border-gray-700 font-bold"
+                  : "text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300 font-medium"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TabButton;

--- a/src/test/TestD.jsx
+++ b/src/test/TestD.jsx
@@ -1,8 +1,5 @@
 import Header from "../components/Header";
 import MenuBar from "../components/MenuBar";
-import PlusButton from "../components/PlusButton";
-import DailyPage from "../pages/DailyPage";
-import { posts } from "../assets/data/dummyPostList";
 
 function TestD() {
   return (
@@ -10,9 +7,9 @@ function TestD() {
       <Header />
       <div className="flex">
         <MenuBar />
-        <DailyPage posts={posts} />
       </div>
     </div>
   );
 }
+
 export default TestD;


### PR DESCRIPTION
## 📌 제목

- TabButton 컴포넌트 구현

## 💡 개요

- Tab버튼을 공통컴포넌트로 만들어서 상위컴포넌트에서 원하는 탭이름으로 재사용하게 분리

## 📝 상세 내용

- "전체", "내가작성글", "일정스토리", "완료된일", "해야할일","할일","루틴", "언젠가", "일정스토리" 등의 탭이름을 넣어서 원하는 위치에서 꺼내쓸 수 있게 구현
- 클릭했을 때 해당탭에 스타일 변경
- 상위컴포넌트에서 필터링가능

## ✅ 체크리스트

- [ ] lint 검사 통과
- [ ] 테스트 통과


## 🔗 관련 이슈

- #75 

<img width="1152" height="719" alt="스크린샷 2025-09-21 오전 1 23 17" src="https://github.com/user-attachments/assets/c97cd566-c4e4-4702-b785-60cf94e605bb" />

