### PR TITLE
feat: 일정상세페이지 추가(#22)

### DIFF
--- a/src/assets/data/dummyDetailSchedule.js
+++ b/src/assets/data/dummyDetailSchedule.js
@@ -1,0 +1,42 @@
+const myScheduleData = {
+  data: {
+    id: 1,
+    title: "일본여행",
+    schedule: [
+      {
+        id: 1,
+        title: "우동 먹으러 가기",
+        description: "신주쿠역 유명 A우동집",
+        start_time: "09:00:00",
+        end_time: "10:00:00",
+      },
+      {
+        id: 2,
+        title: "호텔 체크인",
+        description: "신주쿠역 도보 5분 B호텔",
+        start_time: "13:00:00",
+        end_time: "14:00:00",
+      },
+      // 네 일정 더 추가 가능
+      {
+        id: 3,
+        title: "낮잠자기 ",
+        description: "호텔에서 23421342412341234123123412시간동안 낮잠",
+        start_time: "14:00:00",
+        end_time: "15:00:00",
+      },
+      {
+        id: 4,
+        title: "호텔 체크아웃임",
+        description: "199999999999999999999999999999972년후 체크아웃",
+        start_time: "15:00:00",
+        end_time: "16:00:00",
+      },
+    ],
+    is_shared: true,
+    like_count: 3,
+    bookmark_count: 4,
+  },
+};
+
+export default myScheduleData;

--- a/src/pages/DetailSchedulePage.jsx
+++ b/src/pages/DetailSchedulePage.jsx
@@ -2,9 +2,19 @@ import React from "react";
 import DetailScheduleCard from "../components/DetailScheduleCard";
 import TimeCard from "../components/TimeCard";
 import PlusButton from "../components/PlusButton";
+import myScheduleData from "../assets/data/dummyDetailSchedule";
 
-// scheduleList는 이제 props로 받을 거야!
-function DetailSchedulePage({ scheduleList }) {
+function DetailSchedulePage() {
+  const { data } = myScheduleData;
+  const scheduleList = data.schedule.map(
+    ({ id, title, description, start_time, end_time }) => ({
+      id,
+      title,
+      description,
+      time: `${start_time.slice(0, 5)}~${end_time.slice(0, 5)}`,
+    })
+  );
+
   const handleAddClick = () => {
     console.log("항목추가 버튼 클릭 (기능 없음)");
   };
@@ -12,32 +22,28 @@ function DetailSchedulePage({ scheduleList }) {
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold mb-6 flex items-center gap-2">
-        <span role="img" aria-label="비행기">
-          ✈️
-        </span>
-        일본 여행
+        {data.title} {/* 동적으로 데이터에서 받아온 제목 */}
       </h1>
 
       <div className="relative flex flex-col">
-        {/* 타임카드 뒤 관통 점선 (위치 조정!) */}
+        {/* 점선 */}
         <div
-          className="absolute top-5 left-12 h-[calc(100%-2rem)] border-l-4 border-dashed border-gray-400" // <--- top-5로 살짝 위로 올림!
+          className="absolute top-5 left-12 h-[calc(100%-2rem)] border-l-4 border-dashed border-gray-400"
           style={{ zIndex: 0 }}
         />
 
-        {scheduleList.map(({ time, title, description }, idx) => (
+        {/* 일정 카드 리스트 */}
+        {scheduleList.map(({ id, time, title, description }) => (
           <div
-            key={idx}
+            key={id}
             className="flex items-center mb-6 last:mb-0 relative z-10"
           >
-            {" "}
-            {/* <--- items-center로 변경 */}
             <TimeCard time={time} />
             <DetailScheduleCard title={title} description={description} />
           </div>
         ))}
 
-        {/* 기존 하단 추가하기 버튼 대신 PlusButton 쓰기 */}
+        {/* 플러스 버튼 */}
         <PlusButton onClick={handleAddClick} />
       </div>
     </div>

--- a/src/pages/DetailSchedulePage.jsx
+++ b/src/pages/DetailSchedulePage.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import DetailScheduleCard from "../components/DetailScheduleCard";
+import TimeCard from "../components/TimeCard";
+// import { CiCirclePlus } from "react-icons/ci"; // 더 이상 CiCirclePlus는 안 쓸 거야!
+import { FaRegPlusSquare } from "react-icons/fa"; // <--- 모서리 각진 플러스 아이콘으로 변경!
+
+// scheduleList는 이제 props로 받을 거야!
+function DetailSchedulePage({ scheduleList }) {
+  const handleAddClick = () => {
+    console.log("항목추가 버튼 클릭 (기능 없음)");
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-6 flex items-center gap-2">
+        <span role="img" aria-label="비행기">
+          ✈️
+        </span>
+        일본 여행
+      </h1>
+
+      <div className="relative flex flex-col">
+        {/* 타임카드 뒤 관통 점선 (위치 조정!) */}
+        <div
+          className="absolute top-5 left-12 h-[calc(100%-2rem)] border-l-4 border-dashed border-gray-400" // <--- top-5로 살짝 위로 올림!
+          style={{ zIndex: 0 }}
+        />
+
+        {scheduleList.map(({ time, title, description }, idx) => (
+          <div
+            key={idx}
+            className="flex items-center mb-6 last:mb-0 relative z-10"
+          >
+            {" "}
+            {/* <--- items-center로 변경 */}
+            <TimeCard time={time} />
+            <DetailScheduleCard title={title} description={description} />
+          </div>
+        ))}
+
+        {/* 오른쪽 하단 추가하기 버튼 (FaRegPlusSquare 아이콘으로 변경) */}
+        <button
+          type="button"
+          onClick={handleAddClick}
+          className="absolute bottom-5 right-1 flex items-center gap-1 text-gray-500 hover:text-gray-800 cursor-pointer"
+        >
+          <FaRegPlusSquare size={20} />
+          {/* <--- FaRegPlusSquare 아이콘으로 변경! */}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default DetailSchedulePage;

--- a/src/pages/DetailSchedulePage.jsx
+++ b/src/pages/DetailSchedulePage.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import DetailScheduleCard from "../components/DetailScheduleCard";
 import TimeCard from "../components/TimeCard";
-// import { CiCirclePlus } from "react-icons/ci"; // 더 이상 CiCirclePlus는 안 쓸 거야!
-import { FaRegPlusSquare } from "react-icons/fa"; // <--- 모서리 각진 플러스 아이콘으로 변경!
+import PlusButton from "../components/PlusButton";
 
 // scheduleList는 이제 props로 받을 거야!
 function DetailSchedulePage({ scheduleList }) {
@@ -38,15 +37,8 @@ function DetailSchedulePage({ scheduleList }) {
           </div>
         ))}
 
-        {/* 오른쪽 하단 추가하기 버튼 (FaRegPlusSquare 아이콘으로 변경) */}
-        <button
-          type="button"
-          onClick={handleAddClick}
-          className="absolute bottom-5 right-1 flex items-center gap-1 text-gray-500 hover:text-gray-800 cursor-pointer"
-        >
-          <FaRegPlusSquare size={20} />
-          {/* <--- FaRegPlusSquare 아이콘으로 변경! */}
-        </button>
+        {/* 기존 하단 추가하기 버튼 대신 PlusButton 쓰기 */}
+        <PlusButton onClick={handleAddClick} />
       </div>
     </div>
   );

--- a/src/test/TestJ.jsx
+++ b/src/test/TestJ.jsx
@@ -1,11 +1,65 @@
-import React, { useState, useEffect } from "react";
-import LoadingPage from "../pages/LoadingPage"; // 상대경로 주의!!!
+// src/test/TestJ.jsx
+
+import React from "react";
+import DetailSchedulePage from "../pages/DetailSchedulePage";
+
+// 데이터는 형식 바꿔서 이렇게 JSON 구조로 넣었어
+const myScheduleData = {
+  data: {
+    id: 1,
+    title: "일본여행",
+    schedule: [
+      {
+        id: 1,
+        title: "우동 먹으러 가기",
+        description: "신주쿠역 유명 A우동집…",
+        start_time: "09:00:00",
+        end_time: "10:00:00",
+      },
+      {
+        id: 2,
+        title: "호텔 체크인",
+        description: "신주쿠역 도보 5분 B호텔…",
+        start_time: "13:00:00",
+        end_time: "14:00:00",
+      },
+      // 네 일정 더 추가 가능
+      {
+        id: 3,
+        title: "낮잠자기 ",
+        description: "호텔에서 23421342412341234123123412시간동안 낮잠",
+        start_time: "14:00:00",
+        end_time: "15:00:00",
+      },
+      {
+        id: 4,
+        title: "호텔 체크아웃",
+        description: "199999999999999999999999999999972년후 체크아웃",
+        start_time: "15:00:00",
+        end_time: "16:00:00",
+      },
+    ],
+    is_shared: true,
+    like_count: 3,
+    bookmark_count: 4,
+  },
+};
 
 function TestJ() {
-  return (
-    // DetailSchedulePage 컴포넌트에 데이터 props로 전달!
-    <DetailSchedulePage scheduleList={myScheduleData} />
+  // HH:mm:ss → HH:mm 변환 함수
+  const formatTime = (timeStr) => timeStr.slice(0, 5);
+
+  // JSON data.schedule 배열 맵 돌면서 시간 합쳐서 넘기기
+  const scheduleList = myScheduleData.data.schedule.map(
+    ({ id, title, description, start_time, end_time }) => ({
+      id,
+      title,
+      description,
+      time: `${formatTime(start_time)}~${formatTime(end_time)}`,
+    })
   );
+
+  return <DetailSchedulePage scheduleList={scheduleList} />;
 }
 
 export default TestJ;

--- a/src/test/TestJ.jsx
+++ b/src/test/TestJ.jsx
@@ -33,7 +33,7 @@ const myScheduleData = {
       },
       {
         id: 4,
-        title: "호텔 체크아웃",
+        title: "호텔 체크아웃임",
         description: "199999999999999999999999999999972년후 체크아웃",
         start_time: "15:00:00",
         end_time: "16:00:00",

--- a/src/test/TestJ.jsx
+++ b/src/test/TestJ.jsx
@@ -1,65 +1,7 @@
-// src/test/TestJ.jsx
-
-import React from "react";
 import DetailSchedulePage from "../pages/DetailSchedulePage";
 
-// 데이터는 형식 바꿔서 이렇게 JSON 구조로 넣었어
-const myScheduleData = {
-  data: {
-    id: 1,
-    title: "일본여행",
-    schedule: [
-      {
-        id: 1,
-        title: "우동 먹으러 가기",
-        description: "신주쿠역 유명 A우동집…",
-        start_time: "09:00:00",
-        end_time: "10:00:00",
-      },
-      {
-        id: 2,
-        title: "호텔 체크인",
-        description: "신주쿠역 도보 5분 B호텔…",
-        start_time: "13:00:00",
-        end_time: "14:00:00",
-      },
-      // 네 일정 더 추가 가능
-      {
-        id: 3,
-        title: "낮잠자기 ",
-        description: "호텔에서 23421342412341234123123412시간동안 낮잠",
-        start_time: "14:00:00",
-        end_time: "15:00:00",
-      },
-      {
-        id: 4,
-        title: "호텔 체크아웃임",
-        description: "199999999999999999999999999999972년후 체크아웃",
-        start_time: "15:00:00",
-        end_time: "16:00:00",
-      },
-    ],
-    is_shared: true,
-    like_count: 3,
-    bookmark_count: 4,
-  },
-};
-
 function TestJ() {
-  // HH:mm:ss → HH:mm 변환 함수
-  const formatTime = (timeStr) => timeStr.slice(0, 5);
-
-  // JSON data.schedule 배열 맵 돌면서 시간 합쳐서 넘기기
-  const scheduleList = myScheduleData.data.schedule.map(
-    ({ id, title, description, start_time, end_time }) => ({
-      id,
-      title,
-      description,
-      time: `${formatTime(start_time)}~${formatTime(end_time)}`,
-    })
-  );
-
-  return <DetailSchedulePage scheduleList={scheduleList} />;
+  return <DetailSchedulePage />;
 }
 
 export default TestJ;

--- a/src/test/TestJ.jsx
+++ b/src/test/TestJ.jsx
@@ -2,22 +2,9 @@ import React, { useState, useEffect } from "react";
 import LoadingPage from "../pages/LoadingPage"; // 상대경로 주의!!!
 
 function TestJ() {
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 3000); // 3초 뒤 로딩 해제
-    return () => clearTimeout(timer);
-  }, []);
-
-  return loading ? (
-    <LoadingPage />
-  ) : (
-    <div className="p-6 text-center text-gray-700">
-      <h1 className="text-2xl font-bold mb-4">
-        로딩 완료! 이게 실제 화면이야~
-      </h1>
-      <p>여기에 네 앱 주 컨텐츠가 들어가면 된다!</p>
-    </div>
+  return (
+    // DetailSchedulePage 컴포넌트에 데이터 props로 전달!
+    <DetailSchedulePage scheduleList={myScheduleData} />
   );
 }
 


### PR DESCRIPTION
## 📌 제목

- 일정상세페이지 구현

## 💡 개요

- 기존의 관련 컴포넌트들을 활용하여 
일정상세페이지 구현

## 📝 상세 내용

- 일정상세카드와 타임카드 컴포넌트를그대로 임포트 해와서 map으로 출력해 게시
- 타임카드 중앙을 관통하는 점선추가
- 화면 오른쪽 하단에 추가 버튼(기능미구현) 있음

- <img width="899" height="444" alt="스크린샷 2025-09-21 오후 12 11 37" src="https://github.com/user-attachments/assets/fde41011-0859-41a6-8179-4ee1c3d4ffd4" />

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호
