### PR TITLE
fix: groupDatesByWeek 다시 import(#95)

### DIFF
--- a/src/components/calendar/MainCalendar.jsx
+++ b/src/components/calendar/MainCalendar.jsx
@@ -1,6 +1,6 @@
-import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
 import DisplayWeeks from "./DisplayWeeks";
 import DisplayDays from "./DisplayDays";
+import { groupDatesByWeek } from "../../utils/groupDatesByWeek";
 
 function MainCalendar({ year, month }) {
   // 매 달 1일


### PR DESCRIPTION
## 📌 제목

- fix: groupDatesByWeek 다시 import(#95)

## 💡 개요

- 오류 해결

## 📝 상세 내용

- 함수 .jsx -> .js로 변경 후 import 변경이 안되서 오류났음
- 다시 import함

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 🔗 관련 이슈

- close #95 
