### PR TITLE
feat: 헤더 드롭다운 구현 (#84)

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -4,8 +4,12 @@ import { IoSearch } from "react-icons/io5";
 import { IoMdNotifications } from "react-icons/io";
 import { FaCircleUser } from "react-icons/fa6";
 import { Link } from "react-router";
+import { useState } from "react";
 
 const Header = () => {
+  const [isDropdownProfile, setIsDropdownProfile] = useState(false);
+  const [isDropdownNotification, setIsDropdownNotification] = useState(false);
+
   return (
     <div>
       <header className="flex items-center justify-between flex-row mx-10 my-3">
@@ -14,8 +18,37 @@ const Header = () => {
         </Link>
         <div className="flex justify-evenly gap-7 text-[#192A2D]">
           <IoSearch size={34} />
-          <IoMdNotifications size={34} />
-          <FaCircleUser size={34} />
+          <div
+            onClick={() => (
+              setIsDropdownNotification((prev) => !prev),
+              setIsDropdownProfile(false)
+            )}
+          >
+            <IoMdNotifications size={34} />
+            {isDropdownNotification && (
+              <div className="p-5 rounded-2xl bg-white shadow-[0_0_40px_-10px_#0000003f] absolute top-20 right-5 flex flex-col justify-center items-center gap-3 z-50 text-gray-400">
+                notification list
+              </div>
+            )}
+          </div>
+          <div
+            onClick={() => (
+              setIsDropdownProfile((prev) => !prev),
+              setIsDropdownNotification(false)
+            )}
+          >
+            <FaCircleUser size={34} />
+            {isDropdownProfile && (
+              <div className="p-5 rounded-2xl bg-white shadow-[0_0_40px_-10px_#0000003f] absolute top-20 right-5 flex flex-col justify-center items-center gap-3 z-50 text-gray-400">
+                <Link to={"/my_page"} className="hover:text-black">
+                  마이페이지
+                </Link>
+                <Link to={"/"} className="hover:text-black">
+                  로그아웃
+                </Link>
+              </div>
+            )}
+          </div>
         </div>
       </header>
       <div className="w-screen border-b border-[#D9D9D9]" />


### PR DESCRIPTION
## 📌 제목

- feat: 헤더 드롭다운 구현 (#84)

## 💡 개요

- 프로필 사진과 알림 아이콘 클릭시 드롭다운 구현

## 📝 상세 내용

- 프로필 사진 클릭시 마이페이지/로그아웃 드롭다운
- 알림 아이콘 클릭 시 알림 리스트 드롭다운

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 🔗 관련 이슈

- close #84 
