### PR TITLE
feat: 일정스토리 권한에 따른 UI(#34)

### DIFF
--- a/src/constants/filterList.js
+++ b/src/constants/filterList.js
@@ -9,6 +9,7 @@ export const FILTER_LABELS = {
   latest: "최신순",
   period: "기간별",
   date: "날짜별",
+  reported: "신고된 글",
 };
 
 export const CATEGORY_OPTION_LIST = [

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -51,6 +51,7 @@ let router = createBrowserRouter([
       },
       {
         path: "/admin/schedule_story",
+        Component: ScheduleStory,
       },
     ],
   },

--- a/src/pages/ScheduleStory.jsx
+++ b/src/pages/ScheduleStory.jsx
@@ -1,12 +1,19 @@
+import { useState } from "react";
 import { posts } from "../assets/data/dummyPostList";
 import FilterButtons from "../components/common/FilterButtons";
 import ScheduleStoryCard from "../components/ScheduleStoryCard";
 
 const ScheduleStory = () => {
+  const [isAdmin] = useState(false);
+  const userFilterButtons = ["category", "latest", "period"];
+  const adminFilterButtons = ["category", "latest", "period", "reported"];
+
   return (
     <div className="w-full flex flex-col p-4">
       <div className="flex flex-row gap-3 mb-4">
-        <FilterButtons keys={["category", "latest", "priority"]} />
+        <FilterButtons
+          keys={isAdmin ? adminFilterButtons : userFilterButtons}
+        />
       </div>
 
       <div className="text-sm p-4 border-t border-gray-200 pb-2">


### PR DESCRIPTION
## 📌 제목

- feat: 일정스토리 권한에 따른 UI(#34)

## 💡 개요

- 일정스토리 권한에 따른 필터링 버튼 변경

## 📝 상세 내용

- 권한에 따른 필터링버튼 변경
- 어드민 일정스토리 페이지 라우팅 연결

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 🔗 관련 이슈

- close #34 
