### PR TITLE
feat: 일정스토리 카드 클릭시 상세페이지로 이동 (#85)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/src/components/ScheduleStoryCard.jsx
+++ b/src/components/ScheduleStoryCard.jsx
@@ -1,4 +1,5 @@
 import { FaBookmark, FaRegBookmark } from "react-icons/fa";
+import { useNavigate } from "react-router";
 // import { RiAlarmWarningFill } from "react-icons/ri";
 // import DeleteButton from "./common/DeleteButton";
 // import { useState } from "react";
@@ -6,6 +7,7 @@ import { FaBookmark, FaRegBookmark } from "react-icons/fa";
 
 function ScheduleStoryCard({ schedule }) {
   // const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const navigate = useNavigate();
 
   // const handleClickDeleteButton = () => {
   //   setIsConfirmModalOpen(true);
@@ -13,8 +15,9 @@ function ScheduleStoryCard({ schedule }) {
 
   return (
     <div
-      className="bg-white px-3 rounded-md cursor-pointer hover:scale-110 hover:shadow
+      className="bg-white p-3 rounded-md cursor-pointer hover:scale-110 hover:shadow
     flex flex-col items-center justify-center gap-1 text-center"
+      onClick={() => navigate(`/schedule_story/${schedule.id}`)}
     >
       {/* 회색 박스 */}
       <div className="bg-gray-300 rounded-md h-32 w-[200px] relative">

--- a/src/components/common/BookmarkButton.jsx
+++ b/src/components/common/BookmarkButton.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { FaBookmark, FaRegBookmark } from "react-icons/fa";
 
-export default function BookmarkButton() {
+export default function BookmarkButton({ size = 20 }) {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const handleBookmarkClick = () => {
     setIsBookmarked(true); // 한 번 클릭하면 계속 true 유지하도록
@@ -10,9 +10,9 @@ export default function BookmarkButton() {
   return (
     <button onClick={handleBookmarkClick} aria-label="북마크 버튼">
       {isBookmarked ? (
-        <FaBookmark className="text-yellow-400 w-6 h-6" /> // 채워진 노란 북마크
+        <FaBookmark size={size} className="text-yellow-400 " /> // 채워진 노란 북마크
       ) : (
-        <FaRegBookmark className="text-gray-400 w-6 h-6" /> // 빈 회색 북마크
+        <FaRegBookmark size={size} className="text-gray-400 " /> // 빈 회색 북마크
       )}
     </button>
   );

--- a/src/components/common/LikeButton.jsx
+++ b/src/components/common/LikeButton.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { FaHeart, FaRegHeart } from "react-icons/fa";
 
-export default function LikeButton() {
+export default function LikeButton({ size = 20 }) {
   // 좋아요 상태만 관리
   const [isLiked, setIsLiked] = useState(false);
 
@@ -12,14 +12,14 @@ export default function LikeButton() {
 
   return (
     <button
-      className="bg-transparent border-none p-1.5 inline-flex items-center justify-center space-x-1 cursor-pointer"
+      className="bg-transparent border-none inline-flex items-center justify-center space-x-1 cursor-pointer"
       title={isLiked ? "좋아요 취소" : "좋아요"}
       onClick={handleClick}
     >
       {isLiked ? (
-        <FaHeart className="text-red-500" />
+        <FaHeart size={size} className="text-red-500" />
       ) : (
-        <FaRegHeart className="text-gray-400" />
+        <FaRegHeart size={size} className="text-gray-400" />
       )}
     </button>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,7 @@ import ScheduleStory from "./pages/ScheduleStory";
 import Someday from "./pages/Someday";
 import Daily from "./pages/Daily";
 import AdminPage from "./pages/AdminPage";
+import ScheduleStoryDetailPage from "./pages/ScheduleStoryDetailPage";
 
 let router = createBrowserRouter([
   {
@@ -40,6 +41,10 @@ let router = createBrowserRouter([
       {
         path: "/schedule_story",
         Component: ScheduleStory,
+      },
+      {
+        path: "/schedule_story/:scheduleStoryId",
+        Component: ScheduleStoryDetailPage,
       },
       {
         path: "/search",

--- a/src/pages/ScheduleStory.jsx
+++ b/src/pages/ScheduleStory.jsx
@@ -22,7 +22,7 @@ const ScheduleStory = () => {
 
       <div className="flex flex-wrap justify-center items-center gap-2">
         {posts.data.map((post) => (
-          <div key={post.id} className="py-4">
+          <div key={post.id}>
             <ScheduleStoryCard schedule={post} />
           </div>
         ))}

--- a/src/pages/ScheduleStoryDetailPage.jsx
+++ b/src/pages/ScheduleStoryDetailPage.jsx
@@ -43,7 +43,7 @@ export default function ScheduleStoryDetailPage() {
         </div>
 
         <div className="flex items-start gap-4">
-          <div className="like-wrapper flex flex-col items-center">
+          <div className="flex flex-col items-center">
             <LikeButton />
             <span className="text-xs text-gray-600 mt-1">
               {data.like_count}

--- a/src/pages/ScheduleStoryDetailPage.jsx
+++ b/src/pages/ScheduleStoryDetailPage.jsx
@@ -6,13 +6,15 @@ import DetailScheduleCard from "../components/DetailScheduleCard";
 import LikeButton from "../components/common/LikeButton";
 import BookmarkButton from "../components/common/BookmarkButton";
 import myScheduleData from "../assets/data/dummyDetailSchedule";
-import { PiSirenDuotone } from "react-icons/pi";
+import { RiAlarmWarningFill } from "react-icons/ri";
 import { IoChevronBackSharp } from "react-icons/io5";
 import formatDateAndDay from "../utils/formatDateAndDay";
 import groupSchedulesByDate from "../utils/groupSchedulesByDate";
 import getDayCounts from "../utils/getDayCounts";
+import { useNavigate } from "react-router";
 
 export default function ScheduleStoryDetailPage() {
+  const navigate = useNavigate();
   const { data } = myScheduleData;
 
   // 날짜별 일정 묶기 & 정렬
@@ -22,23 +24,25 @@ export default function ScheduleStoryDetailPage() {
   const dayCounts = getDayCounts(data.start_period, data.end_period);
 
   return (
-    <div className="p-4 min-h-screen bg-white text-gray-900">
+    <div className="w-[100vw-200px] flex flex-col gap-10 p-5 text-gray-900">
       {/* 상단 헤더 */}
-      <header className="flex items-center justify-between mb-6">
-        <button
-          type="button"
-          aria-label="뒤로 가기"
-          className="text-2xl font-bold cursor-pointer text-gray-600 hover:text-gray-800 transition-colors"
-          onClick={() => {}}
-        >
-          <IoChevronBackSharp />
-        </button>
+      <header className="w-[100%] flex items-center justify-between">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            aria-label="뒤로 가기"
+            className="text-2xl font-bold cursor-pointer text-gray-600 hover:text-gray-800 transition-colors"
+            onClick={() => navigate(-1)}
+          >
+            <IoChevronBackSharp size={30} />
+          </button>
 
-        <h1 className="flex-2 text-left font-semibold text-lg truncate">
-          {data.title}
-        </h1>
+          <h1 className="text-left font-semibold text-2xl truncate">
+            {data.title}
+          </h1>
+        </div>
 
-        <div className="flex items-center space-x-4">
+        <div className="flex items-start gap-4">
           <div className="like-wrapper flex flex-col items-center">
             <LikeButton />
             <span className="text-xs text-gray-600 mt-1">
@@ -46,7 +50,7 @@ export default function ScheduleStoryDetailPage() {
             </span>
           </div>
 
-          <div className="bookmark-wrapper flex flex-col items-center">
+          <div className="flex flex-col items-center">
             <BookmarkButton />
             <span className="text-xs text-gray-600 mt-1">
               {data.bookmark_count}
@@ -60,7 +64,7 @@ export default function ScheduleStoryDetailPage() {
             className="cursor-pointer text-gray-700 hover:text-red-600 transition-colors p-1"
             onClick={() => {}}
           >
-            <PiSirenDuotone className="w-6 h-6" />
+            <RiAlarmWarningFill size={25} />
           </button>
         </div>
       </header>


### PR DESCRIPTION
## 📌 제목

- feat: 일정스토리 카드 클릭시 상세페이지로 이동 (#85)

## 💡 개요

- 일정스토리 카드 클릭 시 상세페이지로 이동

## 📝 상세 내용

- 일정스토리 카드 클릭시 해당 상세페이지로 라우팅
- 상세페이지에서 이전 버튼 클릭 시 전 페이지로 이동

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 🔗 관련 이슈

- close #85 
