### PR TITLE
feat: 루틴페이지 일정 렌더(#157)

### DIFF
--- a/src/assets/data/dummyRoutine.js
+++ b/src/assets/data/dummyRoutine.js
@@ -1,0 +1,60 @@
+export const RoutineSchedules = [
+  {
+    id: 0,
+    title: "수영하기",
+    start_period: "2025-10-03T11:04:14.084Z",
+    end_period: "2025-10-03T11:04:14.084Z",
+    category: 0,
+    category_name: "learning",
+    priority: "중간",
+    share_type: "비공개",
+    is_someday: true,
+    is_completed: true,
+    // detail_schedule: [
+    //   {
+    //     "id": 0,
+    //     "title": "string",
+    //     "description": "string",
+    //     "start_time": "2025-10-03T11:04:14.084Z",
+    //     "end_time": "2025-10-03T11:04:14.084Z",
+    //     "is_completed": true
+    //   }
+    // ],
+    recurrence_rule: {
+      id: 0,
+      recurrence_type: "DAILY",
+      weekdays: [],
+      month_of_year: "",
+      day_of_month: "",
+    },
+  },
+  {
+    id: 0,
+    title: "영어공부",
+    start_period: "2025-10-03T11:04:14.084Z",
+    end_period: "2025-11-03T11:04:14.084Z",
+    category: 0,
+    category_name: "learning",
+    priority: "중간",
+    share_type: "비공개",
+    is_someday: true,
+    is_completed: false,
+    // detail_schedule: [
+    //   {
+    //     "id": 0,
+    //     "title": "string",
+    //     "description": "string",
+    //     "start_time": "2025-10-03T11:04:14.084Z",
+    //     "end_time": "2025-10-03T11:04:14.084Z",
+    //     "is_completed": true
+    //   }
+    // ],
+    recurrence_rule: {
+      id: 0,
+      recurrence_type: "DAILY",
+      weekdays: [],
+      month_of_year: "",
+      day_of_month: "",
+    },
+  },
+];

--- a/src/components/DailyRoutineCard.jsx
+++ b/src/components/DailyRoutineCard.jsx
@@ -1,0 +1,22 @@
+import { FaCheckSquare, FaRegSquare } from "react-icons/fa";
+import { getColorOfPriority } from "../utils/getColorOfPriority.js";
+import { getCategoryEmoji } from "../utils/getCategoryEmoji.js";
+
+const DailyRoutineCard = ({ schedule }) => {
+  const { priority, category_name, title, is_completed } = schedule;
+  const priorityColor = getColorOfPriority(priority);
+  const categoryEmoji = getCategoryEmoji(category_name);
+
+  return (
+    <div
+      className={`w-full flex justify-between items-center text-sm px-2 ml-1 border-l-4 ${priorityColor} cursor-pointer`}
+    >
+      <span className="truncate">
+        {categoryEmoji} {title}
+      </span>
+      {is_completed ? <FaCheckSquare /> : <FaRegSquare />}
+    </div>
+  );
+};
+
+export default DailyRoutineCard;

--- a/src/components/RenderRecurrenceByType.jsx
+++ b/src/components/RenderRecurrenceByType.jsx
@@ -1,12 +1,14 @@
-const RenderRecurrenceByType = ({ recurrence }) => {
-  switch (recurrence.type) {
-    case "daily":
-      return "";
-    case "weekly":
+const RenderRecurrenceByType = ({ endPeriod, recurrence }) => {
+  switch (recurrence.recurrence_type) {
+    case "DAILY":
+      return `~ ${new Date(endPeriod).getFullYear()}.${
+        new Date(endPeriod).getMonth() + 1
+      }.${new Date(endPeriod).getDate()}`;
+    case "WEEKLY":
       return recurrence.weekdays.map((day, i) => <span key={i}>{day} </span>);
-    case "monthly":
+    case "MONTHLY":
       return recurrence.day_of_month + "일";
-    case "yearly":
+    case "YEARLY":
       return `${recurrence.month_of_year}월 ${recurrence.day_of_month}일`;
   }
 };

--- a/src/components/RoutineCard.jsx
+++ b/src/components/RoutineCard.jsx
@@ -9,10 +9,17 @@ import { useState } from "react";
 import ConfirmModal from "./common/ConfirmModal.jsx";
 
 const RoutineCard = ({ post }) => {
-  const { priority, recurrence, start_period, is_shared, title, is_completed } =
-    post;
+  const {
+    priority,
+    recurrence_rule,
+    start_period,
+    end_period,
+    share_type,
+    title,
+    is_completed,
+  } = post;
   const priorityColor = getColorOfPriority(priority);
-  const recurrenceType = getRecurrenceType(recurrence.type);
+  const recurrenceType = getRecurrenceType(recurrence_rule.recurrence_type);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   const handleClickDeleteButton = () => {
@@ -24,12 +31,12 @@ const RoutineCard = ({ post }) => {
       className={`flex items-center gap-4 border-l-4 ${priorityColor} pl-3 py-2`}
     >
       {/* 왼쪽: 날짜 + 아이콘 */}
-      <div className="flex flex-col items-start min-w-[140px]">
+      <div className="w-[200px] flex flex-col items-start min-w-[140px]">
         <p className="text-l font-bold text-gray-700 flex items-center gap-2">
           {start_period
             ? new Date(start_period).toLocaleDateString("ko-KR")
             : "-"}
-          {is_shared ? (
+          {share_type !== "비공개" ? (
             <IoShare className="text-gray-500" />
           ) : (
             <FaUser className="text-gray-500" />
@@ -37,7 +44,10 @@ const RoutineCard = ({ post }) => {
         </p>
         <p className="text-sm text-[#C2C2C2]">
           {recurrenceType}반복 :{" "}
-          <RenderRecurrenceByType recurrence={recurrence} />
+          <RenderRecurrenceByType
+            endPeriod={end_period}
+            recurrence={recurrence_rule}
+          />
         </p>
       </div>
 

--- a/src/components/ScheduleCard.jsx
+++ b/src/components/ScheduleCard.jsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { getColorOfPriority } from "../utils/getColorOfPriority";
 
 const ScheduleCard = ({ post }) => {
-  const { priority, start_time, is_shared, title, is_completed, schedule } =
+  const { priority, start_time, share_type, title, is_completed, schedule } =
     post;
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const priorityColor = getColorOfPriority(priority);
@@ -25,7 +25,7 @@ const ScheduleCard = ({ post }) => {
       <div className="flex flex-col items-start min-w-[140px]">
         <p className="text-l font-bold text-gray-700 flex items-center gap-2">
           {start_time ? new Date(start_time).toLocaleDateString("ko-KR") : "-"}
-          {is_shared ? (
+          {share_type !== "비공개" ? (
             <IoShare className="text-gray-500" />
           ) : (
             <FaUser className="text-gray-500" />

--- a/src/components/Weekly.jsx
+++ b/src/components/Weekly.jsx
@@ -1,8 +1,28 @@
-const Weekly = ({ firstDateOfThisWeek }) => {
+import { RoutineSchedules } from "../assets/data/dummyRoutine";
+import DailyRoutineCard from "./DailyRoutineCard";
+import moment from "moment/moment";
+
+const Weekly = ({
+  currentDate,
+  currentDayOfThisWeek,
+  firstDateOfThisWeek,
+  lastDateOfThisWeek,
+}) => {
+  const routineScheduleList = RoutineSchedules.filter(
+    (schedule) =>
+      new Date(schedule.start_period) <= lastDateOfThisWeek &&
+      new Date(schedule.end_period) >= firstDateOfThisWeek
+  );
   const thisWeek = [];
 
   for (let i = 0; i < 7; i++) {
-    thisWeek.push(firstDateOfThisWeek + i);
+    thisWeek.push(
+      new Date(
+        currentDate.getFullYear(),
+        currentDate.getMonth(),
+        currentDate.getDate() - currentDayOfThisWeek + i
+      )
+    );
   }
 
   return (
@@ -18,9 +38,26 @@ const Weekly = ({ firstDateOfThisWeek }) => {
               : "text-black"
           } border-t border-[#000000] ${
             el === thisWeek[6] ? "border-r-0" : "border-r"
-          } h-[100%] p-[15px_0]`}
+          } h-full p-[15px_0] flex flex-col gap-3`}
         >
-          {el}
+          {el.getDate()}
+          <div className="w-full flex flex-col gap-3 text-black">
+            {routineScheduleList.map((schedule) => {
+              if (
+                moment(el).isSameOrAfter(
+                  new Date(schedule.start_period),
+                  "day"
+                ) &&
+                moment(el).isSameOrBefore(
+                  new Date(schedule.end_period),
+                  "day"
+                ) &&
+                schedule.recurrence_rule.recurrence_type === "DAILY"
+              ) {
+                return <DailyRoutineCard schedule={schedule} />;
+              }
+            })}
+          </div>
         </div>
       ))}
     </div>

--- a/src/pages/Routine.jsx
+++ b/src/pages/Routine.jsx
@@ -7,24 +7,31 @@ import { BsList } from "react-icons/bs";
 import { CiCalendar } from "react-icons/ci";
 import { useState } from "react";
 import FilterButtons from "../components/common/FilterButtons";
-import { posts } from "../assets/data/dummyPostList";
 import RoutineCard from "../components/RoutineCard";
 import TabButton from "../components/common/TabButton";
 import PlusButton from "../components/common/PlusButton";
 import AddScheduleModal from "../components/scheduleModal/AddScheduleModal";
+import { RoutineSchedules } from "../assets/data/dummyRoutine";
+import { toTime } from "../utils/dateFormat";
 
 const Routine = () => {
   const [isWeekly, setIsWeekly] = useState(true);
   const [currentDate, setCurrentDate] = useState(new Date());
-  const thisYear = currentDate.getFullYear();
-  const thisMonth = currentDate.getMonth() + 1;
   const currentDayOfThisWeek = currentDate.getDay();
-  const firstDateOfThisWeek = currentDate.getDate() - currentDayOfThisWeek;
-  const lastDateOfThisWeek = currentDate.getDate() + (6 - currentDayOfThisWeek);
+  const firstDateOfThisWeek = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth(),
+    currentDate.getDate() - currentDayOfThisWeek
+  );
+  const lastDateOfThisWeek = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth(),
+    currentDate.getDate() + (6 - currentDayOfThisWeek)
+  );
 
   const [isAddScheduleOpen, setIsAddScheduleOpen] = useState(false);
   const filterKeys = ["period", "date", "priority"];
-  const list = posts.data;
+  const list = RoutineSchedules;
 
   const handleClickListButton = () => {
     setIsWeekly(false);
@@ -63,24 +70,28 @@ const Routine = () => {
       {isWeekly && (
         <div className="h-[100%] flex flex-col gap-3 mx-5">
           <Button onClick={() => setCurrentDate(new Date())}>오늘</Button>
-          <h1 className="flex items-center gap-1 text-2xl font-bold pb-3">
-            <div className="w-[270px]">
-              {thisYear}.{thisMonth}.{firstDateOfThisWeek} ~ {thisYear}.
-              {thisMonth}.{lastDateOfThisWeek}
+          <h1 className="flex items-center gap-1 text-xl font-bold pb-3">
+            <div className="w-[350px] flex flex-col">
+              {toTime(firstDateOfThisWeek)} ~ {toTime(lastDateOfThisWeek)}
             </div>
             <MdOutlineNavigateBefore onClick={handleClickPrev} />
             <MdOutlineNavigateNext onClick={handleClickNext} />
           </h1>
           <DisplayDays />
-          <Weekly firstDateOfThisWeek={firstDateOfThisWeek} />
+          <Weekly
+            currentDate={currentDate}
+            currentDayOfThisWeek={currentDayOfThisWeek}
+            firstDateOfThisWeek={firstDateOfThisWeek}
+            lastDateOfThisWeek={lastDateOfThisWeek}
+          />
         </div>
       )}
       {!isWeekly && (
         <div className="flex flex-col gap-1  mx-6">
           <FilterButtons keys={filterKeys} />
           <h1 className="flex items-center gap-3 pb-3">
-            {thisYear}.{thisMonth}.{firstDateOfThisWeek} ~ {thisYear}.
-            {thisMonth}.{lastDateOfThisWeek}
+            {toTime(firstDateOfThisWeek)} ~
+            <span>{toTime(lastDateOfThisWeek)}</span>
           </h1>
           <div className="w-full -mx-6">
             <TabButton />

--- a/src/utils/getRecurrenceType.js
+++ b/src/utils/getRecurrenceType.js
@@ -1,12 +1,12 @@
 export const getRecurrenceType = (type) => {
   switch (type) {
-    case "daily":
+    case "DAILY":
       return "매일";
-    case "weekly":
+    case "WEEKLY":
       return "매주";
-    case "monthly":
+    case "MONTHLY":
       return "매달";
-    case "yearly":
+    case "YEARLY":
       return "매년";
   }
 };


### PR DESCRIPTION
## 📌 제목

- feat: 루틴페이지 일정 렌더(#157)

## 💡 개요

- 루틴 페이지에 더비 일정데이터를 렌더링

## 📝 상세 내용

- 

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과

## 🔗 관련 이슈

- close #157 
